### PR TITLE
Fixes a bug where includes are not visible to parent projects when rs_driver is submoduled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ if(WIN32)
   cmake_policy(SET CMP0074 NEW)
 endif(WIN32)
 project(rs_driver VERSION 1.3.0)
+add_library(rs_driver INTERFACE)
+
 
 #=============================
 #  Compile Demos&Tools
@@ -83,6 +85,7 @@ endif(WIN32)
 
 find_package(Boost COMPONENTS system date_time regex REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
+target_include_directories(${PROJECT_NAME} INTERFACE ${Boost_INCLUDE_DIRS})
 list(APPEND EXTERNAL_LIBS ${Boost_LIBRARIES})
 
 #========================
@@ -92,6 +95,7 @@ if(WIN32)
   set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
   find_package(PCAP REQUIRED)
   include_directories(${PCAP_INCLUDE_DIR})
+  target_include_directories(${PROJECT_NAME} INTERFACE ${PCAP_INCLUDE_DIR})
   list(APPEND EXTERNAL_LIBS ${PCAP_LIBRARY})
 else()
   list(APPEND EXTERNAL_LIBS pcap)
@@ -104,6 +108,7 @@ if(${ENABLE_TRANSFORM})
   add_definitions("-DENABLE_TRANSFORM")
   find_package(Eigen3 REQUIRED)
   include_directories(${EIGEN3_INCLUDE_DIR})
+  target_include_directories(${PROJECT_NAME} INTERFACE ${EIGEN3_INCLUDE_DIR})
   message(=============================================================)
   message("-- Enable Transform Fcuntions")
   message(=============================================================)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ endif(WIN32)
 project(rs_driver VERSION 1.3.0)
 add_library(rs_driver INTERFACE)
 
-
 #=============================
 #  Compile Demos&Tools
 #=============================

--- a/src/rs_driver/driver/decoder/decoder_factory.hpp
+++ b/src/rs_driver/driver/decoder/decoder_factory.hpp
@@ -51,7 +51,7 @@ public:
   ~DecoderFactory() = default;
   static std::shared_ptr<DecoderBase<T_Point>> createDecoder(const RSDriverParam& param);
 
-private:
+public:
   static const LidarConstantParameter getRS16ConstantParam();
   static const LidarConstantParameter getRS32ConstantParam();
   static const LidarConstantParameter getRSBPConstantParam();


### PR DESCRIPTION
Howdy, couple line change to fix a bug with sub-moduling this library.

`add_library(rs_driver INTERFACE)` makes the project a header only library so that `target_include_directories `properly get forwarded to parent projects. Without this parent projects will fail to find the headers when used as submodules (particularly useful for windows users).

Also changed the lidar params from private to public as these are very useful to get param settings for user.