### PR TITLE
Add time_offset support

### DIFF
--- a/src/rs_driver/driver/driver_param.h
+++ b/src/rs_driver/driver/driver_param.h
@@ -104,6 +104,7 @@ typedef struct RSDecoderParam  ///< LiDAR decoder parameter
   uint32_t num_pkts_split = 1;         ///< Number of packets in one frame, only be used when split_frame_mode=3
   float cut_angle = 0.0f;              ///< Cut angle(degree) used to split frame, only be used when split_frame_mode=1
   bool use_lidar_clock = false;        ///< true: use LiDAR clock as timestamp; false: use system clock as timestamp
+  float time_offset = 0.0;             ///< Timestamp offset in seconds
   RSTransformParam transform_param;    ///< Used to transform points
   RSCameraTriggerParam trigger_param;  ///< Used to trigger camera
   void print() const                  
@@ -117,6 +118,7 @@ typedef struct RSDecoderParam  ///< LiDAR decoder parameter
     RS_INFOL << "start_angle: " << start_angle << RS_REND;
     RS_INFOL << "end_angle: " << end_angle << RS_REND;
     RS_INFOL << "use_lidar_clock: " << use_lidar_clock << RS_REND;
+    RS_INFOL << "time_offset: " << time_offset << RS_REND;
     RS_INFOL << "split_frame_mode: " << split_frame_mode << RS_REND;
     RS_INFOL << "num_pkts_split: " << num_pkts_split << RS_REND;
     RS_INFOL << "cut_angle: " << cut_angle << RS_REND;

--- a/src/rs_driver/driver/lidar_driver_impl.hpp
+++ b/src/rs_driver/driver/lidar_driver_impl.hpp
@@ -426,11 +426,11 @@ inline void LidarDriverImpl<T_Point>::processMsop()
         setPointCloudMsgHeader(msg);
         if (driver_param_.decoder_param.use_lidar_clock == true)
         {
-          msg.timestamp = lidar_decoder_ptr_->getLidarTime(pkt.packet.data());
+          msg.timestamp = lidar_decoder_ptr_->getLidarTime(pkt.packet.data()); // Time offset alredy applied in getLidarTime
         }
         else
         {
-          msg.timestamp = getTime();
+          msg.timestamp = getTime() + driver_param_.decoder_param.time_offset;
         }
         if (msg.point_cloud_ptr->size() == 0)
         {
@@ -480,10 +480,10 @@ inline void LidarDriverImpl<T_Point>::processDifop()
 template <typename T_Point>
 inline void LidarDriverImpl<T_Point>::setScanMsgHeader(ScanMsg& msg)
 {
-  msg.timestamp = getTime();
+  msg.timestamp = getTime() + driver_param_.decoder_param.time_offset;
   if (driver_param_.decoder_param.use_lidar_clock == true)
   {
-    msg.timestamp = lidar_decoder_ptr_->getLidarTime(msg.packets.back().packet.data());
+    msg.timestamp = lidar_decoder_ptr_->getLidarTime(msg.packets.back().packet.data()); // Time offset alredy applied in getLidarTime
   }
   msg.seq = scan_seq_++;
   msg.frame_id = driver_param_.frame_id;


### PR DESCRIPTION
Add time_offset capability to the driver for finetuning timestamps.

Quick implementation only tested on BPearl.