### PR TITLE
fix: Resolve build error with gcc 15 on Linux

### DIFF
--- a/src/rs_driver/driver/driver_param.hpp
+++ b/src/rs_driver/driver/driver_param.hpp
@@ -36,6 +36,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rs_driver/msg/imu_data_msg.hpp"
 #include <string>
 #include <map>
+#include <cstdint>
 #include <cstring>
 #include <unordered_map>
 namespace robosense


### PR DESCRIPTION
This fixes the following build error.
```
driver_param.hpp:41:1: ‘uint16_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   40 | #include <unordered_map>
  +++ |+#include <cstdint>
   41 | namespace robosense
```