### PR TITLE
macOS support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,9 +62,13 @@ if(MSVC)
   add_compile_definitions(_DISABLE_EXTENDED_ALIGNED_STORAGE) # to disable a msvc error
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:100000000")
 
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
+       CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR
+       CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 
-  if(UNIX)
+  if(APPLE)
+    set(COMPILER "macOS Clang Compiler")
+  elseif(UNIX)
     set(COMPILER "UNIX GNU Compiler")
   elseif(MINGW)
     set(COMPILER "MINGW Compiler")

--- a/src/rs_driver/driver/input/unix/input_sock_select.hpp
+++ b/src/rs_driver/driver/input/unix/input_sock_select.hpp
@@ -51,7 +51,39 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 #include <memory>
 #include <cerrno>
-#include <cstring> 
+#include <cstring>
+
+#ifdef __APPLE__
+#include <sys/uio.h>
+
+struct mmsghdr {
+  struct msghdr msg_hdr;
+  unsigned int  msg_len;
+};
+
+static int recvmmsg(int sockfd, struct mmsghdr* msgvec, unsigned int vlen, int flags, struct timespec* /*timeout*/)
+{
+  unsigned int i = 0;
+  for (i = 0; i < vlen; ++i)
+  {
+    ssize_t ret = recvmsg(sockfd, &msgvec[i].msg_hdr, flags);
+    if (ret < 0)
+    {
+      if (errno == EAGAIN || errno == EWOULDBLOCK)
+        return (i > 0) ? (int)i : -1;
+      if (errno == EINTR)
+      {
+        if (i > 0) return (int)i;
+        --i;
+        continue;
+      }
+      return (i == 0) ? -1 : (int)i;
+    }
+    msgvec[i].msg_len = (unsigned int)ret;
+  }
+  return (int)i;
+}
+#endif
 
 namespace robosense
 {

--- a/src/rs_driver/driver/input/unix/input_sock_select.hpp
+++ b/src/rs_driver/driver/input/unix/input_sock_select.hpp
@@ -54,35 +54,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstring>
 
 #ifdef __APPLE__
-#include <sys/uio.h>
-
-struct mmsghdr {
-  struct msghdr msg_hdr;
-  unsigned int  msg_len;
-};
-
-static int recvmmsg(int sockfd, struct mmsghdr* msgvec, unsigned int vlen, int flags, struct timespec* /*timeout*/)
-{
-  unsigned int i = 0;
-  for (i = 0; i < vlen; ++i)
-  {
-    ssize_t ret = recvmsg(sockfd, &msgvec[i].msg_hdr, flags);
-    if (ret < 0)
-    {
-      if (errno == EAGAIN || errno == EWOULDBLOCK)
-        return (i > 0) ? (int)i : -1;
-      if (errno == EINTR)
-      {
-        if (i > 0) return (int)i;
-        --i;
-        continue;
-      }
-      return (i == 0) ? -1 : (int)i;
-    }
-    msgvec[i].msg_len = (unsigned int)ret;
-  }
-  return (int)i;
-}
+#include <rs_driver/driver/input/unix/macos_recvmmsg.hpp>
 #endif
 
 namespace robosense

--- a/src/rs_driver/driver/input/unix/macos_recvmmsg.hpp
+++ b/src/rs_driver/driver/input/unix/macos_recvmmsg.hpp
@@ -1,0 +1,67 @@
+/*********************************************************************************************************************
+Copyright (c) 2020 RoboSense
+All rights reserved
+
+By downloading, copying, installing or using the software you agree to this license. If you do not agree to this
+license, do not download, install, copy or use the software.
+
+License Agreement
+For RoboSense LiDAR SDK Library
+(3-clause BSD License)
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the names of the RoboSense, nor Suteng Innovation Technology, nor the names of other contributors may be used
+to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************************************************************/
+
+#pragma once
+
+#ifdef __APPLE__
+#include <sys/uio.h>
+#include <sys/socket.h>
+#include <errno.h>
+
+struct mmsghdr {
+  struct msghdr msg_hdr;
+  unsigned int  msg_len;
+};
+
+static int recvmmsg(int sockfd, struct mmsghdr* msgvec, unsigned int vlen, int flags, struct timespec* /*timeout*/)
+{
+  unsigned int i = 0;
+  for (i = 0; i < vlen; ++i)
+  {
+    ssize_t ret = recvmsg(sockfd, &msgvec[i].msg_hdr, flags);
+    if (ret < 0)
+    {
+      if (errno == EAGAIN || errno == EWOULDBLOCK)
+        return (i > 0) ? (int)i : -1;
+      if (errno == EINTR)
+      {
+        if (i > 0) return (int)i;
+        --i;
+        continue;
+      }
+      return (i == 0) ? -1 : (int)i;
+    }
+    msgvec[i].msg_len = (unsigned int)ret;
+  }
+  return (int)i;
+}
+#endif


### PR DESCRIPTION
I have added some small changes to add support of macOS builds. The main part is a shim to support `recvmmsg` on Darwin (similar to qnx shim).

I've tested the build and functionality on Tahoe 26.4.1 from a `nix` based build environment.

The online demo program successfully receives data from a Helios device in my test env.