### PR TITLE
fix: add missing standard library includes for header self-containment

### DIFF
--- a/src/rs_driver/driver/driver_param.hpp
+++ b/src/rs_driver/driver/driver_param.hpp
@@ -38,6 +38,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <map>
 #include <cstring>
 #include <unordered_map>
+#include <cstdint>
 namespace robosense
 {
 namespace lidar

--- a/src/rs_driver/driver/input/input.hpp
+++ b/src/rs_driver/driver/input/input.hpp
@@ -39,6 +39,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <thread>
 #include <cstring>
 #include <cstdint>
+#include <memory>
 
 #define VLAN_HDR_LEN  4
 #define ETH_HDR_LEN   42

--- a/src/rs_driver/driver/input/input.hpp
+++ b/src/rs_driver/driver/input/input.hpp
@@ -38,6 +38,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <functional>
 #include <thread>
 #include <cstring>
+#include <cstdint>
 
 #define VLAN_HDR_LEN  4
 #define ETH_HDR_LEN   42


### PR DESCRIPTION
## Summary

Adds missing standard library includes (`<cstdint>` and `<memory>`) to `driver_param.hpp` and `input.hpp` to ensure header self-containment and prevent compilation errors in strict build environments.

## Problem

Two critical headers use standard library types without explicitly including the required headers, violating C++ best practices and causing compilation failures in some environments.

### Compilation Errors (Without This Fix)

```bash
error: 'uint8_t' does not name a type
error: 'uint16_t' does not name a type
error: 'uint32_t' does not name a type
error: 'shared_ptr' is not a member of 'std'
note: 'std::shared_ptr' is defined in header '<memory>'; did you forget to '#include <memory>'?
